### PR TITLE
Add Hanzilla Jobs Canada science roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Help wanted: academia
      Use a ### Country subsection (e.g. "### Canada"). If the country already exists, add your entry there.
      If it does not exist, add a new ### subsection in alphabetical order among the existing countries.
      Keep entries within each country section in alphabetical order. -->
+### Canada
+
+* [Hanzilla Jobs Sciences](https://jobs.hanzilla.co/sciences/) - Canadian student and recent-graduate science roles across biology, biotech, geology, lab, data, and related early-career fields.
+
 ### Germany
 
 * [FaBI](https://bioinformatik.de/)


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs Sciences under the Canada regional section.
- Link directly to the science-field landing page rather than the homepage.

## Why it may fit
Hanzilla Jobs is a free, public, daily-updated Canadian student/recent-grad job board. The linked science page includes early-career science-adjacent listings such as biology, biotech, lab, geology, data, and related roles, so it may be useful for Canadian students/recent grads browsing regional bio/science job resources.

If this is too broad for a bioinformatics-specific list, no worries — happy to adjust or close.

## Checklist
- Direct HTTPS jobs/resource URL
- One-sentence description, capitalized and ending with a period
- Added under Regional → Canada
